### PR TITLE
fix: Redirect oomusou.io to old-oomusou.goodjack.tw

### DIFF
--- a/琐碎知识点.md
+++ b/琐碎知识点.md
@@ -32,7 +32,7 @@ supervisorctl reload
 > + 持久性(Durability) : 持久性表示在某个事务的执行过程中，对数据所作的所有改动都必须在事务成功结束前保存至某种物理存储设备。这样可以保证，所作的修改在任何系统瘫痪时不至于丢失。
 
 #### 关于架构 For Laravel
-- http://oomusou.io/laravel/laravel-architecture/
+- https://old-oomusou.goodjack.tw/laravel/architecture/
 
 #### Laravel 版本升级相关
 - 很麻烦


### PR DESCRIPTION
舊的 oomusou.io 文章已經轉移至 old-oomusou.goodjack.tw